### PR TITLE
Small documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,18 @@ If you install the library in a Symfony2 application, you can add this in your c
 # app/config/config.yml
 doctrine:
     orm:
-    # ...
-    entity_managers:
-        default:
-            # ...
-            dql:
-                numeric_functions:
-                    rand:        Mapado\MysqlDoctrineFunctions\DQL\MysqlRand
-                    round:       Mapado\MysqlDoctrineFunctions\DQL\MysqlRound
-                datetime_functions:
-                    date:        Mapado\MysqlDoctrineFunctions\DQL\MysqlDate
-                    date_format: Mapado\MysqlDoctrineFunctions\DQL\MysqlDateFormat
-                # ... add all functions you need
+        # ...
+        entity_managers:
+            default:
+                # ...
+                dql:
+                    numeric_functions:
+                        rand:        Mapado\MysqlDoctrineFunctions\DQL\MysqlRand
+                        round:       Mapado\MysqlDoctrineFunctions\DQL\MysqlRound
+                    datetime_functions:
+                        date:        Mapado\MysqlDoctrineFunctions\DQL\MysqlDate
+                        date_format: Mapado\MysqlDoctrineFunctions\DQL\MysqlDateFormat
+                    # ... add all functions you need
 ```
 
 ### Usage


### PR DESCRIPTION
According to the [docs](http://symfony.com/doc/current/reference/configuration/doctrine.html), the key `entity_managers` must be under `orm`, not directly under `doctrine`.
