### PR TITLE
Added support to call ROUND() without round precision

### DIFF
--- a/DQL/MysqlRound.php
+++ b/DQL/MysqlRound.php
@@ -39,10 +39,11 @@ class MysqlRound extends FunctionNode
      */
     public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
     {
-        return 'ROUND(' .
-            $sqlWalker->walkSimpleArithmeticExpression($this->simpleArithmeticExpression) .','.
-            (is_null($this->roundPrecision) ? 0 : $sqlWalker->walkStringPrimary($this->roundPrecision)) .
-        ')';
+        return sprintf(
+            'ROUND(%s, %s)',
+            $sqlWalker->walkSimpleArithmeticExpression($this->simpleArithmeticExpression),
+            (is_null($this->roundPrecision) ? 0 : $sqlWalker->walkStringPrimary($this->roundPrecision))
+        );
     }
 
     /**

--- a/DQL/MysqlRound.php
+++ b/DQL/MysqlRound.php
@@ -1,8 +1,10 @@
 <?php
 namespace Mapado\MysqlDoctrineFunctions\DQL;
 
+use Doctrine\ORM\Query\AST\ArithmeticExpression;
 use \Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use \Doctrine\ORM\Query\Lexer;
+use \Doctrine\ORM\Query\QueryException;
 
 /**
  * MysqlRound
@@ -21,12 +23,12 @@ class MysqlRound extends FunctionNode
     public $simpleArithmeticExpression;
 
     /**
-     * roundPrecission
+     * roundPrecision
      *
      * @var mixed
      * @access public
      */
-    public $roundPrecission;
+    public $roundPrecision;
 
     /**
      * getSql
@@ -38,8 +40,8 @@ class MysqlRound extends FunctionNode
     public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
     {
         return 'ROUND(' .
-                $sqlWalker->walkSimpleArithmeticExpression($this->simpleArithmeticExpression) .','.
-                $sqlWalker->walkStringPrimary($this->roundPrecission) .
+            $sqlWalker->walkSimpleArithmeticExpression($this->simpleArithmeticExpression) .','.
+            (is_null($this->roundPrecision) ? 0 : $sqlWalker->walkStringPrimary($this->roundPrecision)) .
         ')';
     }
 
@@ -56,10 +58,12 @@ class MysqlRound extends FunctionNode
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
 
         $this->simpleArithmeticExpression = $parser->SimpleArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->roundPrecission = $parser->ArithmeticExpression();
-        if ($this->roundPrecission == null) {
-            $this->roundPrecission = 0;
+
+        try {
+            $parser->match(Lexer::T_COMMA);
+            $this->roundPrecision = $parser->ArithmeticExpression();
+        } catch(QueryException $e) {
+            // ROUND() is being used without round precision
         }
 
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);


### PR DESCRIPTION
MySQL supports calling ROUND() without a round precision and uses 0 instead. I tried this with the doctrine ROUND() function and got a QueryException because a comma/literal was expected.

So i fixed the parser to support ROUND() without a round precision.

Also fixed typo in "$roundPrecission".
